### PR TITLE
实现消息持久化功能

### DIFF
--- a/src/common/protocol.proto
+++ b/src/common/protocol.proto
@@ -133,15 +133,6 @@ message heartbeatResponse {
     string rid = 1;
 }
 
-
-message heartbeatRequest {
-    string rid = 1;
-}
-
-message heartbeatResponse {
-    string rid = 1;
-}
-
 message queueStatusRequest {
     string rid = 1;
     string cid = 2;

--- a/src/server/queue_message.hpp
+++ b/src/server/queue_message.hpp
@@ -3,8 +3,12 @@
 #include <deque>
 #include <memory>
 #include <string>
-#include <algorithm>            // 新增
-#include "../common/msg.pb.h"      // BasicProperties
+#include <fstream>
+#include <mutex>
+#include <filesystem>
+#include <algorithm>
+
+#include "../common/msg.pb.h"      // BasicProperties / Message
 #include "../common/message.hpp"   // 若已有真正定义则直接用它
 
 namespace hz_mq {
@@ -24,42 +28,157 @@ class queue_message {
 public:
     using ptr = std::shared_ptr<queue_message>;
 
-    queue_message(const std::string&, const std::string&) {}   // base_dir / queue_name
+    queue_message(const std::string& base_dir, const std::string& queue_name);
+    ~queue_message();
 
     bool insert(BasicProperties* bp,
                 const std::string& body,
-                bool /*durable_unused*/)
-    {
-        auto msg = std::make_shared<Message>();
-
-        if (bp)
-            *msg->mutable_payload()->mutable_properties() = *bp;   // 复制属性
-
-        msg->mutable_payload()->set_body(body);
-        msgs_.push_back(std::move(msg));
-        return true;
-    }
+                bool durable);
 
     message_ptr front() const
     {   return msgs_.empty() ? nullptr : msgs_.front(); }
 
-    void remove(const std::string& id)      // id 为空 ⇒ 删除队首
-    {
-        if (id.empty()) { if (!msgs_.empty()) msgs_.pop_front(); return; }
-
-        msgs_.erase(std::remove_if(msgs_.begin(), msgs_.end(),
-                    [&](const message_ptr& m){
-                        return m && m->payload().properties().id() == id;
-                    }),
-                    msgs_.end());
-    }
+    void remove(const std::string& id);      // id 为空 ⇒ 删除队首
 
     std::size_t getable_count() const { return msgs_.size(); }
 
-    void recovery() {}   // TODO: 以后实现磁盘恢复
+    void recovery();   // 从磁盘恢复
 
 private:
+    bool write_persistent(message_ptr& msg);
+    void invalidate_persistent(const message_ptr& msg);
+
     std::deque<message_ptr> msgs_;
+    std::string            file_path_;
+    mutable std::mutex     mtx_;
+    std::fstream           file_;
 };
 
-}   
+} // namespace hz_mq
+
+// ==================== Implementation ====================
+inline hz_mq::queue_message::queue_message(const std::string& base_dir,
+                                           const std::string& queue_name)
+    : file_path_(base_dir + "/" + queue_name + ".mqd")
+{
+    namespace fs = std::filesystem;
+    if (!fs::exists(base_dir))
+        fs::create_directories(base_dir);
+
+    file_.open(file_path_, std::ios::in | std::ios::out | std::ios::binary);
+    if (!file_.is_open()) {
+        file_.clear();
+        file_.open(file_path_, std::ios::out | std::ios::binary);
+        file_.close();
+        file_.open(file_path_, std::ios::in | std::ios::out | std::ios::binary);
+    }
+}
+
+inline hz_mq::queue_message::~queue_message()
+{
+    if (file_.is_open()) file_.close();
+}
+
+inline bool hz_mq::queue_message::write_persistent(message_ptr& msg)
+{
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (!file_.is_open()) return false;
+
+    msg->mutable_payload()->set_valid("1");
+    std::string data;
+    msg->payload().SerializeToString(&data);
+    uint32_t len = static_cast<uint32_t>(data.size());
+
+    file_.seekp(0, std::ios::end);
+    std::streampos pos = file_.tellp();
+    file_.write(reinterpret_cast<const char*>(&len), sizeof(len));
+    file_.write(data.data(), data.size());
+    file_.flush();
+
+    msg->set_offset(static_cast<uint64_t>(pos));
+    msg->set_length(sizeof(len) + len);
+    return file_.good();
+}
+
+inline bool hz_mq::queue_message::insert(BasicProperties* bp,
+                                         const std::string& body,
+                                         bool durable)
+{
+    auto msg = std::make_shared<Message>();
+    if (bp)
+        *msg->mutable_payload()->mutable_properties() = *bp;
+    msg->mutable_payload()->set_body(body);
+
+    if (durable)
+        write_persistent(msg);
+
+    msgs_.push_back(std::move(msg));
+    return true;
+}
+
+inline void hz_mq::queue_message::invalidate_persistent(const message_ptr& msg)
+{
+    if (msg->length() == 0) return;
+
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (!file_.is_open()) return;
+
+    MessagePayload payload = msg->payload();
+    payload.set_valid("0");
+    std::string data;
+    payload.SerializeToString(&data);
+    uint32_t len = static_cast<uint32_t>(data.size());
+
+    file_.seekp(msg->offset() + sizeof(uint32_t), std::ios::beg);
+    file_.write(data.data(), len);
+    file_.flush();
+}
+
+inline void hz_mq::queue_message::remove(const std::string& id)
+{
+    if (msgs_.empty()) return;
+
+    if (id.empty()) {
+        auto msg = msgs_.front();
+        invalidate_persistent(msg);
+        msgs_.pop_front();
+        return;
+    }
+
+    for (auto it = msgs_.begin(); it != msgs_.end(); ++it) {
+        if ((*it)->payload().properties().id() == id) {
+            invalidate_persistent(*it);
+            msgs_.erase(it);
+            break;
+        }
+    }
+}
+
+inline void hz_mq::queue_message::recovery()
+{
+    std::lock_guard<std::mutex> lk(mtx_);
+    if (!file_.is_open()) return;
+
+    file_.seekg(0, std::ios::beg);
+    std::streampos pos = file_.tellg();
+    while (true) {
+        uint32_t len = 0;
+        if (!file_.read(reinterpret_cast<char*>(&len), sizeof(len))) break;
+        std::string data(len, '\0');
+        if (!file_.read(&data[0], len)) break;
+
+        MessagePayload payload;
+        if (!payload.ParseFromString(data)) break;
+
+        auto msg = std::make_shared<Message>();
+        *msg->mutable_payload() = payload;
+        msg->set_offset(static_cast<uint64_t>(pos));
+        msg->set_length(sizeof(len) + len);
+
+        if (payload.valid() == "1")
+            msgs_.push_back(std::move(msg));
+
+        pos = file_.tellg();
+    }
+}
+

--- a/test/test_persistence.cpp
+++ b/test/test_persistence.cpp
@@ -1,0 +1,24 @@
+#include <gtest/gtest.h>
+#include "../src/server/queue_message.hpp"
+#include "../src/common/msg.pb.h"
+
+using namespace hz_mq;
+
+TEST(Persistence, StoreAndRecover) {
+    {
+        queue_message qm("./persist_data", "pq");
+        BasicProperties bp;
+        bp.set_delivery_mode(DeliveryMode::DURABLE);
+        qm.insert(&bp, "hello", true);
+        qm.insert(&bp, "world", true);
+    }
+
+    queue_message qm2("./persist_data", "pq");
+    qm2.recovery();
+    ASSERT_EQ(qm2.getable_count(), 2u);
+    EXPECT_EQ(qm2.front()->payload().body(), "hello");
+    qm2.remove("");
+    EXPECT_EQ(qm2.front()->payload().body(), "world");
+
+    std::filesystem::remove_all("./persist_data");
+}


### PR DESCRIPTION
## Summary
- 支持 queue_message 将消息写入磁盘文件并在启动时恢复
- 修复 protocol.proto 重复定义
- 新增消息持久化单元测试

## Testing
- `make mq_test` *(fails: gtest/gtest.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687150693fc4832ba60991d0c4294398