### PR TITLE
Add queue management HTTP API

### DIFF
--- a/src/server/broker_server.hpp
+++ b/src/server/broker_server.hpp
@@ -98,6 +98,8 @@ private:
     void on_declareQueueWithDLQ(const muduo::net::TcpConnectionPtr&, const declareQueueWithDLQRequestPtr&, muduo::Timestamp);
     void on_basicNack     (const muduo::net::TcpConnectionPtr&, const basicNackRequestPtr&,      muduo::Timestamp);
     void on_queueStatusRequest(const muduo::net::TcpConnectionPtr&, const queueStatusRequestPtr&, muduo::Timestamp);
+
+    virtual_host::ptr get_virtual_host() const { return __virtual_host; }
 private:
     std::unique_ptr<muduo::net::EventLoop>   __loop;
     std::unique_ptr<muduo::net::TcpServer>   __server;

--- a/src/server/main.cpp
+++ b/src/server/main.cpp
@@ -1,4 +1,5 @@
 #include "broker_server.hpp"
+#include "management_http.hpp"
 #include "muduo/net/EventLoop.h"
 #include "muduo/net/TcpServer.h"
 #include "muduo/protoc/dispatcher.h"
@@ -13,6 +14,8 @@ int main(int argc, char* argv[]) {
         base_dir = argv[2];
     }
     hz_mq::BrokerServer server(port, base_dir);
+    hz_mq::management_http_server http_srv(server.get_virtual_host(), 8080);
+    http_srv.start();
     server.start();
     return 0;
 }

--- a/src/server/management_http.cpp
+++ b/src/server/management_http.cpp
@@ -1,0 +1,88 @@
+#include "management_http.hpp"
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <unistd.h>
+#include <cstring>
+#include <cstdio>
+#include <cstdlib>
+
+namespace hz_mq {
+
+management_http_server::management_http_server(const virtual_host::ptr& host, int port)
+    : __host(host), __port(port) {}
+
+void management_http_server::start() {
+    __th = std::thread(&management_http_server::run, this);
+    __th.detach();
+}
+
+void management_http_server::run() {
+    __listen_fd = ::socket(AF_INET, SOCK_STREAM, 0);
+    int on = 1;
+    ::setsockopt(__listen_fd, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on));
+    sockaddr_in addr{};
+    addr.sin_family = AF_INET;
+    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = htons(__port);
+    ::bind(__listen_fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr));
+    ::listen(__listen_fd, 16);
+    while (true) {
+        int cfd = ::accept(__listen_fd, nullptr, nullptr);
+        if (cfd >= 0) {
+            handle_client(cfd);
+            ::close(cfd);
+        }
+    }
+}
+
+void management_http_server::handle_client(int client_fd) {
+    char buf[4096];
+    ssize_t n = ::read(client_fd, buf, sizeof(buf)-1);
+    if (n <= 0) return;
+    buf[n] = '\0';
+    std::string req(buf, n);
+    auto pos1 = req.find(' ');
+    if (pos1 == std::string::npos) return;
+    auto pos2 = req.find(' ', pos1 + 1);
+    if (pos2 == std::string::npos) return;
+    std::string method = req.substr(0, pos1);
+    std::string path = req.substr(pos1 + 1, pos2 - pos1 - 1);
+
+    if (method == "GET" && path.rfind("/queues/",0) == 0 && path.size() > 8 &&
+        path.find("/stats", 8) != std::string::npos) {
+        std::string qname = path.substr(8, path.size() - 8 - 6);
+        auto qstat = __host->queue_runtime_stats(qname);
+        bool exists = __host->exists_queue(qname);
+        char body[256];
+        std::snprintf(body, sizeof(body),
+                      "{\"exists\":%s,\"depth\":%zu,\"file_size\":%zu,\"invalid_ratio\":%.3f}",
+                      exists?"true":"false", qstat.depth, qstat.file_size, qstat.invalid_ratio);
+        char header[256];
+        std::snprintf(header, sizeof(header),
+                      "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %zu\r\n\r\n",
+                      std::strlen(body));
+        ::write(client_fd, header, std::strlen(header));
+        ::write(client_fd, body, std::strlen(body));
+    } else if (method == "POST" && path.rfind("/queues/",0) == 0 && path.size() > 8 &&
+               path.find("/compact", 8) != std::string::npos) {
+        std::string qname = path.substr(8, path.size() - 8 - 8);
+        __host->compact_queue(qname);
+        const char* body = "{\"ok\":true}";
+        char header[128];
+        std::snprintf(header, sizeof(header),
+                      "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %zu\r\n\r\n",
+                      std::strlen(body));
+        ::write(client_fd, header, std::strlen(header));
+        ::write(client_fd, body, std::strlen(body));
+    } else {
+        const char* body = "Not Found";
+        char header[128];
+        std::snprintf(header, sizeof(header),
+                      "HTTP/1.1 404 Not Found\r\nContent-Length: %zu\r\n\r\n",
+                      std::strlen(body));
+        ::write(client_fd, header, std::strlen(header));
+        ::write(client_fd, body, std::strlen(body));
+    }
+}
+
+} // namespace hz_mq

--- a/src/server/management_http.hpp
+++ b/src/server/management_http.hpp
@@ -1,0 +1,18 @@
+#pragma once
+#include "virtual_host.hpp"
+#include <thread>
+
+namespace hz_mq {
+class management_http_server {
+public:
+    management_http_server(const virtual_host::ptr& host, int port);
+    void start();
+private:
+    void run();
+    void handle_client(int client_fd);
+    virtual_host::ptr __host;
+    int __port;
+    int __listen_fd{-1};
+    std::thread __th;
+};
+}

--- a/src/server/virtual_host.cpp
+++ b/src/server/virtual_host.cpp
@@ -408,4 +408,26 @@ std::string virtual_host::basic_query()
     return {};
 }
 
+queue_message_ptr virtual_host::select_queue_message(const std::string& queue_name)
+{
+    auto it = __queue_messages.find(queue_name);
+    if (it == __queue_messages.end()) return nullptr;
+    return it->second;
+}
+
+queue_message::stats virtual_host::queue_runtime_stats(const std::string& queue_name)
+{
+    auto it = __queue_messages.find(queue_name);
+    if (it == __queue_messages.end()) return {};
+    return it->second->get_stats();
+}
+
+void virtual_host::compact_queue(const std::string& queue_name)
+{
+    auto it = __queue_messages.find(queue_name);
+    if (it != __queue_messages.end()) {
+        it->second->compact();
+    }
+}
+
 } 

--- a/src/server/virtual_host.hpp
+++ b/src/server/virtual_host.hpp
@@ -77,9 +77,14 @@ public:
                              const std::string& body);
     message_ptr basic_consume_and_remove(const std::string& queue_name);
     void basic_ack(const std::string& queue_name, const std::string& msg_id);
-    void basic_nack(const std::string& queue_name, const std::string& msg_id, 
+    void basic_nack(const std::string& queue_name, const std::string& msg_id,
                     bool requeue, const std::string& reason);
     std::string basic_query();  // 简化的 pull 查询
+
+    queue_message::stats queue_runtime_stats(const std::string& queue_name);
+    void compact_queue(const std::string& queue_name);
+
+    queue_message_ptr select_queue_message(const std::string& queue_name);
 
 private:
     std::string                                   __name;


### PR DESCRIPTION
## Summary
- implement `queue_message::get_stats` and `compact`
- expose queue runtime information through `virtual_host`
- add minimal HTTP management server for queue stats and compaction
- start HTTP server in `main`
- provide accessor for `virtual_host` in `BrokerServer`

## Testing
- `make mq_test` *(fails: gtest missing)*

------
https://chatgpt.com/codex/tasks/task_e_6874180767fc832bb7bd7f9e77557c8e